### PR TITLE
externalize mail settings to env variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ typings/
 avatars/
 images/
 react-material-dashboard-master/
+.idea/

--- a/server/src/routes/invitations.js
+++ b/server/src/routes/invitations.js
@@ -19,7 +19,7 @@ const createMailOptions = (data) => {
                 <br/>
               `;
   return {
-    from: 'geosimos91@gmail.com',
+    from: process.env.MAIL_FROM,
     to,
     subject: 'Cinema + Invitation',
     html: htmlContent,

--- a/server/src/utils/mail.js
+++ b/server/src/utils/mail.js
@@ -1,12 +1,12 @@
 const nodemailer = require('nodemailer');
 
 const transporter = nodemailer.createTransport({
-  service: 'gmail', //smtp.gmail.com  //in place of service use host...
-  secure: false, //true
-  port: 25, //465
+  service: process.env.MAIL_SERVICE, // smtp.gmail.com  //in place of service use host...
+  secure: process.env.MAIL_SECURED, // true
+  port: process.env.MAIL_PORT, // 465
   auth: {
-    user: process.env.GMAIL_USER,
-    pass: process.env.GMAIL_PASSWORD,
+    user: process.env.MAIL_USER,
+    pass: process.env.MAIL_PASSWORD,
   },
   tls: {
     rejectUnauthorized: false,
@@ -14,6 +14,7 @@ const transporter = nodemailer.createTransport({
 });
 
 transporter.sendEMail = function(mailRequest) {
+  console.log(transporter)
   return new Promise(function(resolve, reject) {
     transporter.sendMail(mailRequest, (error, info) => {
       if (error) {

--- a/server/src/utils/mail.js
+++ b/server/src/utils/mail.js
@@ -2,7 +2,7 @@ const nodemailer = require('nodemailer');
 
 const transporter = nodemailer.createTransport({
   service: process.env.MAIL_SERVICE, // smtp.gmail.com  //in place of service use host...
-  secure: process.env.MAIL_SECURED, // true
+  secure: process.env.MAIL_SECURE, // true
   port: process.env.MAIL_PORT, // 465
   auth: {
     user: process.env.MAIL_USER,

--- a/server/src/utils/mail.js
+++ b/server/src/utils/mail.js
@@ -2,7 +2,7 @@ const nodemailer = require('nodemailer');
 
 const transporter = nodemailer.createTransport({
   service: process.env.MAIL_SERVICE, // smtp.gmail.com  //in place of service use host...
-  secure: process.env.MAIL_SECURED, // true
+  secure: process.env.MAIL_SECURE, // true
   port: process.env.MAIL_PORT, // 465
   auth: {
     user: process.env.MAIL_USER,
@@ -14,7 +14,6 @@ const transporter = nodemailer.createTransport({
 });
 
 transporter.sendEMail = function(mailRequest) {
-  console.log(transporter)
   return new Promise(function(resolve, reject) {
     transporter.sendMail(mailRequest, (error, info) => {
       if (error) {


### PR DESCRIPTION
externalize mail settings to env file allows flexiablity to use different stmp mail services.
this will probably break your existing deployment which requires update on the server .env file to setup the mail settings.